### PR TITLE
Fix message share link regex

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -47,7 +47,9 @@ impl EventHandler for Handler {
         }
 
         // discord message url
-        let re = match regex::Regex::new(r"https://discord.com/channels/\d+/\d+/\d+") {
+        let re = match regex::Regex::new(
+            r"https://(?:discord\.com|discordapp\.com)/channels/\d+/\d+/\d+",
+        ) {
             Ok(re) => re,
             Err(_) => return,
         };


### PR DESCRIPTION
形式が変わっていた。
テストフェーズなのか、ユーザーや端末によってコピーされるリンクは違うので、新旧両方に対応するようにした。